### PR TITLE
Fix issue preventing different instances of library to work together.…

### DIFF
--- a/jfingerprintmanager/src/main/java/com/jesusm/jfingerprintmanager/base/FingerprintAssetsManager.java
+++ b/jfingerprintmanager/src/main/java/com/jesusm/jfingerprintmanager/base/FingerprintAssetsManager.java
@@ -86,7 +86,7 @@ public class FingerprintAssetsManager {
             return;
         }
 
-        boolean isCipherAvailable = keyStoreManager.isCipherAvailable();
+        boolean isCipherAvailable = cipher != null;
 
         if (callback != null) {
             if (isCipherAvailable) {

--- a/jfingerprintmanager/src/main/java/com/jesusm/jfingerprintmanager/base/keystore/KeyStoreManager.java
+++ b/jfingerprintmanager/src/main/java/com/jesusm/jfingerprintmanager/base/keystore/KeyStoreManager.java
@@ -33,7 +33,6 @@ public class KeyStoreManager {
 
     private KeyGenerator keyGenerator;
     private KeyguardManager keyguardManager;
-    private Cipher defaultCipher;
 
     public KeyStoreManager(Context context) {
         keyguardManager = context.getSystemService(KeyguardManager.class);
@@ -59,9 +58,9 @@ public class KeyStoreManager {
     }
 
     public Cipher initDefaultCipher(String key) throws NewFingerprintEnrolledException, InitialisationException, NoSuchPaddingException, NoSuchAlgorithmException {
-        defaultCipher = createCipher();
-        initCipher(defaultCipher, key);
-        return defaultCipher;
+        Cipher cipher = createCipher();
+        initCipher(cipher, key);
+        return cipher;
     }
 
     /**
@@ -109,13 +108,9 @@ public class KeyStoreManager {
     }
 
     public static class InitialisationException extends Throwable {
-        public InitialisationException(String message, Exception cause) {
+        InitialisationException(String message, Exception cause) {
             super(message, cause);
         }
-    }
-
-    public boolean isCipherAvailable() {
-        return defaultCipher != null;
     }
 
     @Nullable

--- a/jfingerprintmanager/src/test/java/com/jesusm/jfingerprintmanager/authentication/AuthenticationManagerTest.java
+++ b/jfingerprintmanager/src/test/java/com/jesusm/jfingerprintmanager/authentication/AuthenticationManagerTest.java
@@ -11,8 +11,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.security.NoSuchAlgorithmException;
 
+import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,11 +62,11 @@ public class AuthenticationManagerTest extends BaseTest{
     }
 
     @Test
-    public void authenticationDisplayedIfCreationSuccessful() {
+    public void authenticationDisplayedIfCreationSuccessful() throws KeyStoreManager.InitialisationException, KeyStoreManager.NewFingerprintEnrolledException, NoSuchAlgorithmException, NoSuchPaddingException {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
+        when(mockKeyStoreManager.initDefaultCipher(anyString())).thenReturn(Mockito.mock(Cipher.class));
 
         JFingerprintManager.AuthenticationCallback authenticationCallback = Mockito.mock(JFingerprintManager.AuthenticationCallback.class);
         jFingerprintManager.startAuthentication(authenticationCallback, mockFragmentManager);

--- a/jfingerprintmanager/src/test/java/com/jesusm/jfingerprintmanager/encryption/presenter/EncryptionManagerTest.java
+++ b/jfingerprintmanager/src/test/java/com/jesusm/jfingerprintmanager/encryption/presenter/EncryptionManagerTest.java
@@ -2,6 +2,7 @@ package com.jesusm.jfingerprintmanager.encryption.presenter;
 
 import com.jesusm.jfingerprintmanager.BaseTest;
 import com.jesusm.jfingerprintmanager.JFingerprintManager;
+import com.jesusm.jfingerprintmanager.base.keystore.KeyStoreManager;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,10 +11,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.security.NoSuchAlgorithmException;
 
+import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -61,11 +65,11 @@ public class EncryptionManagerTest extends BaseTest {
     }
 
     @Test
-    public void fingerprintDisplayedIfCreationSuccessful() {
+    public void fingerprintDisplayedIfCreationSuccessful() throws KeyStoreManager.InitialisationException, KeyStoreManager.NewFingerprintEnrolledException, NoSuchAlgorithmException, NoSuchPaddingException {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
+        when(mockKeyStoreManager.initDefaultCipher(anyString())).thenReturn(mock(Cipher.class));
 
         JFingerprintManager.EncryptionCallback encryptionCallback = Mockito.mock(JFingerprintManager.EncryptionCallback.class);
         jFingerprintManager.encrypt("message", encryptionCallback, mockFragmentManager);
@@ -79,8 +83,7 @@ public class EncryptionManagerTest extends BaseTest {
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(false);
 
         EncryptionCallbackAdapter callbackAdapter = Mockito.mock(EncryptionCallbackAdapter.class);
-        String message = "message";
-        jFingerprintManager.encrypt(message, callbackAdapter, mockFragmentManager);
+        jFingerprintManager.encrypt("message", callbackAdapter, mockFragmentManager);
 
         verify(callbackAdapter).onFingerprintNotAvailable();
         verify(callbackAdapter, never()).onEncryptionSuccess(anyString());
@@ -91,7 +94,6 @@ public class EncryptionManagerTest extends BaseTest {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
 
         EncryptionCallbackAdapter callbackAdapter = Mockito.mock(EncryptionCallbackAdapter.class);
         jFingerprintManager.encrypt("", callbackAdapter, mockFragmentManager);
@@ -101,11 +103,11 @@ public class EncryptionManagerTest extends BaseTest {
     }
 
     @Test
-    public void encryptionDisplayedIfCreationSuccessful() {
+    public void encryptionDisplayedIfCreationSuccessful() throws KeyStoreManager.InitialisationException, KeyStoreManager.NewFingerprintEnrolledException, NoSuchAlgorithmException, NoSuchPaddingException {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
+        when(mockKeyStoreManager.initDefaultCipher(anyString())).thenReturn(mock(Cipher.class));
 
         JFingerprintManager.EncryptionCallback encryptionCallback = Mockito.mock(JFingerprintManager.EncryptionCallback.class);
         jFingerprintManager.encrypt("message", encryptionCallback, mockFragmentManager);
@@ -118,7 +120,6 @@ public class EncryptionManagerTest extends BaseTest {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
 
         JFingerprintManager.DecryptionCallback callbackAdapter = Mockito.mock(JFingerprintManager.DecryptionCallback.class);
         jFingerprintManager.decrypt("", callbackAdapter, mockFragmentManager);
@@ -132,7 +133,6 @@ public class EncryptionManagerTest extends BaseTest {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
 
         JFingerprintManager.DecryptionCallback callbackAdapter = Mockito.mock(JFingerprintManager.DecryptionCallback.class);
         jFingerprintManager.decrypt("message", callbackAdapter, mockFragmentManager);
@@ -142,18 +142,17 @@ public class EncryptionManagerTest extends BaseTest {
     }
 
     @Test
-    public void decryptionDisplayedIfCreationSuccessful() {
+    public void decryptionDisplayedIfCreationSuccessful() throws KeyStoreManager.InitialisationException, KeyStoreManager.NewFingerprintEnrolledException {
         JFingerprintManager jFingerprintManager = createFingerPrintManager();
         when(mockFingerprintHardware.isFingerprintAuthAvailable()).thenReturn(true);
         when(mockKeyStoreManager.isFingerprintEnrolled()).thenReturn(true);
-        when(mockKeyStoreManager.isCipherAvailable()).thenReturn(true);
+        when(mockKeyStoreManager.initCipherForDecryption(anyString(), any(byte[].class))).thenReturn(Mockito.mock(Cipher.class));
 
         JFingerprintManager.DecryptionCallback callbackAdapter = Mockito.mock(JFingerprintManager.DecryptionCallback.class);
         jFingerprintManager.decrypt("message:ivs", callbackAdapter, mockFragmentManager);
 
         verify(mockSystem).showDialog();
     }
-
 
     private class EncryptionCallbackAdapter implements JFingerprintManager.EncryptionCallback {
 

--- a/sample/src/main/java/jesusm/com/fingerprintmanager/sample/MainActivity.java
+++ b/sample/src/main/java/jesusm/com/fingerprintmanager/sample/MainActivity.java
@@ -2,6 +2,7 @@ package jesusm.com.fingerprintmanager.sample;
 
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.StyleRes;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
@@ -18,9 +19,10 @@ public class MainActivity extends AppCompatActivity {
     private Button authenticateButton;
     private Button encryptTextButton;
     private Button decryptTextButton;
-    private JFingerprintManager fingerPrintManager;
 
     private String messageToDecrypt;
+    @StyleRes
+    private int dialogTheme;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -28,8 +30,6 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         initViews();
-
-        initFingerprintManager();
 
         initClickListeners();
     }
@@ -44,9 +44,11 @@ public class MainActivity extends AppCompatActivity {
         selectView(findViewById(R.id.buttonDialogThemeLight));
     }
 
-    private void initFingerprintManager() {
-        fingerPrintManager = new JFingerprintManager(this, KEY);
-        fingerPrintManager.setAuthenticationDialogStyle(R.style.DialogThemeLight);
+    private JFingerprintManager createFingerprintManagerInstance()
+    {
+        JFingerprintManager fingerprintManager = new JFingerprintManager(this, KEY);
+        fingerprintManager.setAuthenticationDialogStyle(dialogTheme);
+        return fingerprintManager;
     }
 
     private void initClickListeners() {
@@ -58,7 +60,7 @@ public class MainActivity extends AppCompatActivity {
 
                 deselectView(findViewById(R.id.buttonDialogThemeDark));
 
-                fingerPrintManager.setAuthenticationDialogStyle(R.style.DialogThemeLight);
+                dialogTheme = R.style.DialogThemeLight;
             }
         });
 
@@ -69,14 +71,14 @@ public class MainActivity extends AppCompatActivity {
 
                 deselectView(findViewById(R.id.buttonDialogThemeLight));
 
-                fingerPrintManager.setAuthenticationDialogStyle(R.style.DialogThemeDark);
+                dialogTheme = R.style.DialogThemeDark;
             }
         });
 
         authenticateButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                fingerPrintManager.startAuthentication(new JFingerprintManager.AuthenticationCallback() {
+                createFingerprintManagerInstance().startAuthentication(new JFingerprintManager.AuthenticationCallback() {
                     @Override
                     public void onAuthenticationSuccess() {
                         messageTextView.setText("Successfully authenticated");
@@ -109,7 +111,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 messageToDecrypt = messageToBeEncryptedEditText.getText().toString();
-                fingerPrintManager.encrypt(messageToDecrypt, new JFingerprintManager.EncryptionCallback() {
+                createFingerprintManagerInstance().encrypt(messageToDecrypt, new JFingerprintManager.EncryptionCallback() {
                     @Override
                     public void onFingerprintNotRecognized() {
                         messageTextView.setText("Fingerprint not recognized");
@@ -147,7 +149,7 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 messageToDecrypt = messageToBeEncryptedEditText.getText().toString();
-                fingerPrintManager.decrypt(messageToDecrypt, new JFingerprintManager.DecryptionCallback() {
+                createFingerprintManagerInstance().decrypt(messageToDecrypt, new JFingerprintManager.DecryptionCallback() {
                     @Override
                     public void onDecryptionSuccess(String messageDecrypted) {
                         String message = getString(R.string.decrypt_message_success, messageDecrypted);


### PR DESCRIPTION
… (closes #2)

Fixes #2

This code ensures that different instances of the library can work together when encrypting/decrypting.

Previously, when using encryption/decryption feature, an internal field (`defaultCipher`) was initialised in the encryption step. Unfortunately, this field was checked when decrypting, so if one instance set up encryption environment and a different one wanted to decrypt something, this different instance would fail due it didn't have that field initialised.

This code removes that internal instance (and therefore its check) and only checks the temporal ones created in encryption/decryption process. This ensures that different instances of the library can work together.

Thanks @MBontekoning for raising original issue.