### PR TITLE
Update README using new Budybuild badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FingerprintManager-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/5521)
 
-[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=58e4023c2fb30e0001bf5dda&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/58e4023c2fb30e0001bf5dda/build/latest?branch=master)
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5933de925161b7000159e901&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5933de925161b7000159e901/build/latest?branch=master)
 
 KFingerprintManager
 -------------------


### PR DESCRIPTION
After using Kotlin as only programming language for this project, Buddybuild started to fail building and running UT due it was using the already deleted `jfingerprintmanager` module. After creating a new instance for this project in Buddybuild, this code uses proper build badge.