### PR TITLE
Prevent IllegalStateException crash. (closes #12)

### DIFF
--- a/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/authentication/presenter/FingerprintAuthenticationDialogPresenter.kt
+++ b/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/authentication/presenter/FingerprintAuthenticationDialogPresenter.kt
@@ -32,8 +32,8 @@ class FingerprintAuthenticationDialogPresenter(view: View) : FingerprintBaseDial
             }
         }
 
-        (view as View).onPasswordInserted(password)
         close()
+        (view as View).onPasswordInserted(password)
     }
 
     private fun isValidPassword(password: String) : Boolean = password.isNullOrEmpty().not()
@@ -69,8 +69,8 @@ class FingerprintAuthenticationDialogPresenter(view: View) : FingerprintBaseDial
     }
 
     override fun onAuthenticationSucceeded(result: FingerprintManagerCompat.AuthenticationResult) {
-        (view as View).onAuthenticationSucceed()
         close()
+        (view as View).onAuthenticationSucceed()
     }
 
     interface View : FingerprintBaseDialogPresenter.View {

--- a/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/base/ui/FingerprintBaseDialogFragment.kt
+++ b/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/base/ui/FingerprintBaseDialogFragment.kt
@@ -88,7 +88,7 @@ abstract class FingerprintBaseDialogFragment<T : FingerprintBaseDialogPresenter>
     }
 
     override fun close() {
-        dismiss()
+        dismissAllowingStateLoss()
     }
 
     override fun onCancel(dialog: DialogInterface?) {

--- a/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/base/ui/presenter/FingerprintBaseDialogPresenter.kt
+++ b/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/base/ui/presenter/FingerprintBaseDialogPresenter.kt
@@ -65,13 +65,13 @@ abstract class FingerprintBaseDialogPresenter(val view: View, var stage: Stage =
     }
 
     override fun onAuthenticationHelp(helpMsgId: Int, helpString: CharSequence?) {
-        view.onAuthenticationFailedWithHelp(helpString.toString())
         close()
+        view.onAuthenticationFailedWithHelp(helpString.toString())
     }
 
     override fun onAuthenticationFailed() {
-        view.onFingerprintNotRecognized()
         close()
+        view.onFingerprintNotRecognized()
     }
 
     fun onDialogCancelled() =

--- a/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/encryption/presenter/FingerprintEncryptionDialogPresenter.kt
+++ b/kfingerprintmanager/src/main/kotlin/com/jesusm/kfingerprintmanager/encryption/presenter/FingerprintEncryptionDialogPresenter.kt
@@ -22,9 +22,9 @@ class FingerprintEncryptionDialogPresenter(view : View) : FingerprintBaseDialogP
     override fun onAuthenticationSucceeded(result: FingerprintManagerCompat.AuthenticationResult?) {
         super.onAuthenticationSucceeded(result)
 
+        close()
         result?.let {
             (view as View).onAuthenticationSucceed(it.cryptoObject)
         }
-        close()
     }
 }


### PR DESCRIPTION
Fixes #12

This code aims to fix an issue where an IllegalStateException crash could appear when activity is closed from authentication callback. In order to do that, dialog is always closed before calling authentication callback, and dialog closes itself using `dismissAllowStateLoss` which should prevent the `IllegalStateException` crash.

@ptrbrynt Could you give it a go and tell if it works?